### PR TITLE
chore: convert properties to computed refs

### DIFF
--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -1,7 +1,6 @@
 import type { ActJWTClaim, CheckAuthorizationWithCustomPermissions, GetToken, OrganizationCustomRoleKey, SignOut } from '@clerk/types'
-import { toRefs } from '@vueuse/core'
 import { computed } from 'vue'
-import { createGetToken, createSignOut } from '../utils'
+import { createGetToken, createSignOut, toComputedRefs } from '../utils'
 import { invalidStateError, useAuthHasRequiresRoleOrPermission } from '../errors/messages'
 import { useClerkProvide } from './useClerkProvide'
 
@@ -153,5 +152,5 @@ export function useAuth() {
     throw new Error(invalidStateError)
   })
 
-  return toRefs(result)
+  return toComputedRefs(result)
 }

--- a/src/composables/useOrganization.ts
+++ b/src/composables/useOrganization.ts
@@ -1,6 +1,6 @@
 import type { OrganizationResource } from '@clerk/types'
-import { toRefs } from '@vueuse/core'
 import { computed } from 'vue'
+import { toComputedRefs } from '../utils'
 import { useClerkProvide } from './useClerkProvide'
 
 type UseOrganizationReturn =
@@ -32,5 +32,5 @@ export function useOrganization() {
     return { isLoaded: isClerkLoaded.value, organization }
   })
 
-  return toRefs(result)
+  return toComputedRefs(result)
 }

--- a/src/composables/useSession.ts
+++ b/src/composables/useSession.ts
@@ -1,6 +1,6 @@
 import type { ActiveSessionResource } from '@clerk/types'
-import { toRefs } from '@vueuse/core'
 import { computed } from 'vue'
+import { toComputedRefs } from '../utils'
 import { useClerkProvide } from './useClerkProvide'
 
 type UseSessionReturn =
@@ -23,5 +23,5 @@ export function useSession() {
     return { isLoaded: true, isSignedIn: true, session }
   })
 
-  return toRefs(result)
+  return toComputedRefs(result)
 }

--- a/src/composables/useSessionList.ts
+++ b/src/composables/useSessionList.ts
@@ -1,7 +1,7 @@
 import type { SessionResource, SetActive, SetSession } from '@clerk/types'
 import { computed } from 'vue'
 
-import { toRefs } from '@vueuse/core'
+import { toComputedRefs } from '../utils'
 import { useClerkProvide } from './useClerkProvide'
 
 type UseSessionListReturn =
@@ -9,16 +9,19 @@ type UseSessionListReturn =
   | { isLoaded: true, sessions: SessionResource[], setSession: SetSession, setActive: SetActive }
 
 export function useSessionList() {
-  const { clerk, isClerkLoaded } = useClerkProvide()
-  return toRefs(computed<UseSessionListReturn>(() => {
-    if (!isClerkLoaded.value || !clerk.client)
+  const { clerk, state, isClerkLoaded } = useClerkProvide()
+
+  const result = computed<UseSessionListReturn>(() => {
+    if (!isClerkLoaded.value || !state.client)
       return { isLoaded: false, sessions: undefined, setSession: undefined, setActive: undefined }
 
     return {
       isLoaded: true,
-      sessions: clerk.client.sessions,
+      sessions: state.client.sessions,
       setSession: clerk.setSession,
       setActive: clerk.setActive,
     }
-  }))
+  })
+
+  return toComputedRefs(result)
 }

--- a/src/composables/useSignIn.ts
+++ b/src/composables/useSignIn.ts
@@ -1,6 +1,6 @@
 import type { SetActive, SetSession, SignInResource } from '@clerk/types'
-import { toRefs } from '@vueuse/core'
 import { computed } from 'vue'
+import { toComputedRefs } from '../utils'
 import { useClerkProvide } from './useClerkProvide'
 
 type UseSignInReturn =
@@ -22,5 +22,5 @@ export function useSignIn() {
     }
   })
 
-  return toRefs(result)
+  return toComputedRefs(result)
 }

--- a/src/composables/useSignUp.ts
+++ b/src/composables/useSignUp.ts
@@ -1,6 +1,6 @@
 import type { SetActive, SetSession, SignUpResource } from '@clerk/types'
 import { computed } from 'vue'
-import { toRefs } from '@vueuse/core'
+import { toComputedRefs } from '../utils'
 import { useClerkProvide } from './useClerkProvide'
 
 type UseSignUpReturn =
@@ -22,5 +22,5 @@ export function useSignUp() {
     }
   })
 
-  return toRefs(result)
+  return toComputedRefs(result)
 }

--- a/src/composables/useUser.ts
+++ b/src/composables/useUser.ts
@@ -1,6 +1,6 @@
 import type { UserResource } from '@clerk/types'
-import { toRefs } from '@vueuse/core'
 import { computed } from 'vue'
+import { toComputedRefs } from '../utils'
 import { useClerkProvide } from './useClerkProvide'
 
 type UseUserReturn =
@@ -23,5 +23,5 @@ export function useUser() {
     return { isLoaded: true, isSignedIn: true, user }
   })
 
-  return toRefs(result)
+  return toComputedRefs(result)
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import type Clerk from '@clerk/clerk-js'
+import type { ComputedRef } from 'vue'
+import { computed } from 'vue'
 import type { ActiveSessionResource, InitialState, OrganizationCustomPermissionKey, OrganizationCustomRoleKey, OrganizationResource, Resources, UserResource } from '@clerk/types'
 
 export function deriveState(clerkLoaded: boolean, state: Resources, initialState: InitialState | undefined) {
@@ -101,4 +103,19 @@ export function createSignOut(isomorphicClerk: Clerk) {
     await clerkLoaded(isomorphicClerk)
     return isomorphicClerk.signOut(...args)
   }
+}
+
+type ToComputedRefs<T = any> = {
+  [K in keyof T]: ComputedRef<T[K]>;
+}
+
+export function toComputedRefs<T extends object>(
+  objectRef: ComputedRef<T>,
+): ToComputedRefs<T> {
+  const result = {} as any
+
+  for (const key in objectRef.value)
+    result[key] = computed(() => objectRef.value[key])
+
+  return result
 }


### PR DESCRIPTION
This PR removes the `toRefs` util for `vueuse` and makes all properties unwritable.