### PR TITLE
feat(docs): Add reminder for Nuxt plugin filename suffix

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -8,6 +8,9 @@ The plugin provides your application the active session and user context to Cler
 
 ## Usage
 
+::: warning
+When using Nuxt, ensure that your plugin filenames are suffixed with `.client.js` or `.client.ts`. This practice ensures that Nuxt will load them only when Vue is mounted and ready on the client, preventing them from being loaded on the server side.:::
+
 ```ts
 import { createApp } from 'vue'
 import { clerkPlugin } from 'vue-clerk/plugin'


### PR DESCRIPTION
This commit improves the documentation by adding a helpful reminder for fellow developers using Nuxt.js. It suggests appending .client.js or .client.ts to plugin filenames, ensuring Nuxt.js loads them only upon Vue's mounting, thus sidestepping server-side loading. Drawing from my own experience, I encountered and solved this common issue.

Motivation:

The motivation behind this addition is to address a common pitfall encountered by developers when working with Nuxt.js. Without the proper filename suffix, plugins may inadvertently be loaded on the server side, and **crash** the application.