### PR TITLE
match new clerk docs and redirect to props section

### DIFF
--- a/docs/authentication/sign-in.md
+++ b/docs/authentication/sign-in.md
@@ -7,7 +7,15 @@ outline: deep
 <br />
 <img src="https://clerk.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2F_docs%2Fmain%2Fui-components%2Fsign-in.svg&w=1080&q=75" />
 
-The `<SignIn />` component renders a UI for signing in users. The functionality of the `<SignIn />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com). You can further customize your `<SignIn />` component by passing additional properties at the time of rendering.
+The `<SignIn />` component renders a UI for signing in users. The functionality of the `<SignIn />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](https://clerk.com/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](https://clerk.com/docs/authentication/social-connections/overview). You can further customize your `<SignIn />` component by passing additional properties at the time of rendering.
+
+::: info
+The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
+:::
+
+## Props
+
+Click [here](https://clerk.com/docs/components/authentication/sign-in#properties) to see the full list of props available.
 
 ## Usage
 
@@ -19,20 +27,6 @@ import { SignIn } from 'vue-clerk'
 </script>
 
 <template>
-  <SignIn path="/sign-in" routing="path" sign-up-url="/sign-up" />
+  <SignIn path="/sign-in" />
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`appearance`|[`Appearance`](https://clerk.com/docs/components/customization/overview) / `undefined`|Optional object to style your components. Will only affect Clerk Components and not [Account Portal](https://clerk.com/docs/account-portal/overview) pages.|
-|`routing`|`'hash' \|'path' \|'virtual'`|The routing strategy for your pages.Note: If you are using environment variables for Next.js or Remix to specify your routes, this will be set to `path`.|
-|`path`|`string`|The path where the component is mounted on when path-based routing is used e.g. /sign-up.|
-|`redirectUrl`|`string`|Full URL or path to navigate to after successful sign in or sign up.The same as setting afterSignInUrl and afterSignUpUrl to the same value.|
-|`afterSignInUrl`|`string`|The full URL or path to navigate to after a successful sign in.|
-|`signInUrl`|`string`|Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered.|
-|`afterSignUpUrl`|`string`|The full URL or path to navigate after a successful sign up.|
-|`unsafeMetadata`|`object`|An object with the key and value for unsafeMetadata that will be saved to the user after sign up.E.g. `{ "company": "companyID1234" }`|
-|`initialValues`|[`SignUpInitialValues`](https://clerk.com/docs/references/javascript/types/sign-up-initial-values)|The values used to prefill the sign-up fields with.|

--- a/docs/authentication/sign-up.md
+++ b/docs/authentication/sign-up.md
@@ -7,7 +7,15 @@ outline: deep
 <br />
 <img src="https://clerk.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2F_docs%2Fmain%2Fui-components%2Fsign-up.svg&w=1080&q=75" />
 
-The `<SignUp />` component renders a UI for signing up users. The functionality of the `<SignUp />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com). You can further customize your `<SignUp />` component by passing additional properties at the time of rendering.
+The `<SignUp />` component renders a UI for signing up users. The functionality of the `<SignUp />` component is controlled by the instance settings you specify in your [Clerk Dashboard](https://dashboard.clerk.com), such as [sign-in and sign-up options](https://clerk.com/docs/authentication/configuration/sign-up-sign-in-options) and [social connections](https://clerk.com/docs/authentication/social-connections/overview). You can further customize your `<SignUp />` component by passing additional properties at the time of rendering.
+
+::: info
+The `<SignUp/>` and `<SignIn/>` components cannot render when a user is already signed in, unless the application allows multiple sessions. If a user is already signed in and the application only allows a single session, Clerk will redirect the user to the Home URL instead.
+:::
+
+## Props
+
+Click [here](https://clerk.com/docs/components/authentication/sign-up#properties) to see the full list of props available.
 
 ## Usage
 
@@ -19,20 +27,6 @@ import { SignUp } from 'vue-clerk'
 </script>
 
 <template>
-  <SignUp />
+  <SignUp path="/sign-up" />
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`appearance`|[`Appearance`](https://clerk.com/docs/components/customization/overview) / `undefined`|Optional object to style your components. Will only affect Clerk Components and not [Account Portal](https://clerk.com/docs/account-portal/overview) pages.|
-|`routing`|`'hash' \|'path' \|'virtual'`|The routing strategy for your pages.Note: If you are using environment variables for Next.js or Remix to specify your routes, this will be set to `path`.|
-|`path`|`string`|The path where the component is mounted on when path-based routing is used e.g. /sign-up.|
-|`redirectUrl`|`string`|Full URL or path to navigate to after successful sign in or sign up.The same as setting afterSignInUrl and afterSignUpUrl to the same value.|
-|`afterSignInUrl`|`string`|The full URL or path to navigate to after a successful sign in.|
-|`signInUrl`|`string`|Full URL or path to the sign in page. Use this property to provide the target of the 'Sign In' link that's rendered.|
-|`afterSignUpUrl`|`string`|The full URL or path to navigate after a successful sign up.|
-|`unsafeMetadata`|`object`|An object with the key and value for unsafeMetadata that will be saved to the user after sign up.E.g. `{ "company": "companyID1234" }`|
-|`initialValues`|[`SignUpInitialValues`](https://clerk.com/docs/references/javascript/types/sign-up-initial-values)|The values used to prefill the sign-up fields with.|

--- a/docs/composables/use-auth.md
+++ b/docs/composables/use-auth.md
@@ -4,24 +4,38 @@ outline: deep
 
 # useAuth()
 
-Access the auth state inside your Vue components.
+The `useAuth()` composable is a convenient way to access the current auth state. This composable provides the minimal information needed for data-loading and helper methods to manage the current active session.
 
-## Overview
+## Returns
 
-The `useAuth` composable is a convenient way to access the current auth state. This composable provides the minimal information needed for data-loading and helper methods to manage the current active session.
+Click [here](https://clerk.com/docs/references/react/use-auth#use-auth-returns) to see the full list of properties returned.
 
 ## Usage
+
+The following example demonstrates how to use the `useAuth()` composable to access the current auth state, like whether the user is signed in or not. It also demonstrates a basic example of how you could use the `getToken()` method to retrieve a session token for fetching data from an external resource.
 
 ```vue
 <script setup>
 import { useAuth } from 'vue-clerk'
 
-const { isLoaded, userId, sessionId } = useAuth()
+const { getToken, isLoaded, isSignedIn } = useAuth()
+
+const fetchDataFromExternalResource = async () => {
+  const token = await getToken.value();
+  // Add logic to fetch your data
+  return data;
+}
 </script>
 
 <template>
-  <div v-if="isLoaded && userId">
-    Hello, {{ userId }}
+  <div v-if="!isLoaded">
+    Loading...
+  </div>
+  <div v-else-if="!isSignedIn">
+    Sign in to view this page
+  </div>
+  <div v-else>
+    ...
   </div>
 </template>
 ```

--- a/docs/composables/use-auth.md
+++ b/docs/composables/use-auth.md
@@ -20,10 +20,10 @@ import { useAuth } from 'vue-clerk'
 
 const { getToken, isLoaded, isSignedIn } = useAuth()
 
-const fetchDataFromExternalResource = async () => {
-  const token = await getToken.value();
+async function fetchDataFromExternalResource() {
+  const token = await getToken.value()
   // Add logic to fetch your data
-  return data;
+  return data
 }
 </script>
 

--- a/docs/composables/use-clerk.md
+++ b/docs/composables/use-clerk.md
@@ -4,15 +4,17 @@ outline: deep
 
 # useClerk()
 
-Access the Clerk object inside your components.
+The `useClerk()` composable provides access to the [`Clerk`](https://clerk.com/docs/references/javascript/clerk/clerk) object, giving you the ability to build alternatives to any Clerk Component.
 
-## Overview
+::: warning
+This is intended to be used for advanced use cases, like building a completely custom OAuth flow or as an escape hatch for getting access to the `Clerk` object.
+:::
 
-The `useClerk` composable accesses the [Clerk](https://clerk.com/docs/reference/clerkjs/clerk) object. It can be used to retrieve any object in the [ClerkJS](https://reference.clerk.dev/reference/clerkjs) SDK. Moreover, it allows access to all of the [Clerk object's methods](https://clerk.com/docs/reference/clerkjs/clerk#methods), giving you the freedom to build alternatives to any [Clerk Component](https://clerk.com/docs/reference/clerkjs/clerk).
+## Returns
+
+The `useClerk()` composable returns the `Clerk` object, which includes all the methods and properties listed in the [`Clerk` reference](https://clerk.com/docs/references/javascript/clerk/clerk).
 
 ## Usage
-
-An example of the `useClerk` composable in action is shown below. We get access to the [Clerk](https://clerk.com/docs/reference/clerkjs/clerk) object in order to render a button that opens the [sign in](https://clerk.com/docs/component-reference/sign-in) form as a modal.
 
 ```vue
 <script setup>

--- a/docs/composables/use-session-list.md
+++ b/docs/composables/use-session-list.md
@@ -6,12 +6,9 @@ outline: deep
 
 The `useSessionList()` composable returns an array of [`Session`](https://clerk.com/docs/references/javascript/session) objects that have been registered on the client device.
 
-## Properties
+## Returns
 
-|Name|Type|Description|
-|--- |--- |--- |
-|isLoaded|`boolean`|A boolean that is set to `false` until Clerk loads and initializes.|
-|sessions|[`Session[]`](https://clerk.com/docs/references/javascript/session)|A boolean that is set to `false` until Clerk loads and initializes.|
+Click [here](https://clerk.com/docs/references/react/use-session-list#use-session-list-returns) to see the full list of properties returned.
 
 ## Usage
 

--- a/docs/composables/use-session.md
+++ b/docs/composables/use-session.md
@@ -4,31 +4,32 @@ outline: deep
 
 # useSession()
 
-Access the current Session object inside your components.
+The `useSession()` composable provides access to the current user's [`Session`](https://clerk.com/docs/references/javascript/session) object, as well as helpers for setting the active session.
 
-## Overview
+## Returns
 
-The `useSession` composable accesses the current user [Session](https://clerk.com/docs/reference/clerkjs/session) object. It can be used to retrieve information about the session status. The `useSession` composable is a shortcut for retrieving the [Clerk.session](https://clerk.com/docs/reference/clerkjs/clerk#session) property.
-
-As soon as a [User](https://clerk.com/docs/reference/clerkjs/user) signs in, we create a [Session](https://clerk.com/docs/reference/clerkjs/session) on the [Client](https://clerk.com/docs/reference/clerkjs/client) object. Only one session can be active on a single client, and that's exactly the session that is returned by the `useSession` composable.
-
-The Session object returned from the composable will hold all state for the currently active session.
+Click [here](https://clerk.com/docs/references/react/use-session#use-session-returns) to see the full list of properties returned.
 
 ## Usage
 
-The following example accesses the [Session](https://clerk.com/docs/reference/clerkjs/session) object in order to display how long a user has been active in this client session. Note that you can also get to the [User](https://clerk.com/docs/reference/clerkjs/user) object through the `useSession` composable.
+The following example demonstrates how to use the `useSession()` composable to access the `SignIn` object, which has the `lastActiveAt` property on it. The `lastActiveAt` property is used to display the last active time of the current session to the user.
 
 ```vue
 <script setup>
 import { useSession } from 'vue-clerk'
 
-const { isLoaded, session } = useSession()
+const { isLoaded, session, isSignedIn } = useSession()
 </script>
 
 <template>
-  <div v-if="isLoaded && session">
-    This session has been active
-    since {{ session.lastActiveAt }}.
+  <div v-if="!isLoaded">
+    Loading...
+  </div>
+  <div v-else-if="!isSignedIn">
+    Not signed in
+  </div>
+  <div v-else>
+    This session has been active since {{ session.lastActiveAt.toLocaleString() }}.
   </div>
 </template>
 ```

--- a/docs/composables/use-sign-in.md
+++ b/docs/composables/use-sign-in.md
@@ -4,21 +4,17 @@ outline: deep
 
 # useSignIn()
 
-Access the SignIn object inside of your components.
+The `useSignIn()` composable provides access to the [`SignIn`](https://clerk.com/docs/references/javascript/sign-in/sign-in) object, which allows you to check the current state of a sign-in. This is also useful for creating a custom sign-in flow.
 
-## Overview
+## Returns
 
-The `useSignIn` composable gives you access to the [SignIn](https://clerk.com/docs/reference/clerkjs/signin) object inside your components.
-
-You can use the methods of the `SignIn` object to create your own custom sign in flow, as an alternative to using Clerk's pre-built [<SignIn/>](/authentication/sign-in.html) component.
-
-The `SignIn` object will also contain the state of the sign in attempt that is currently in progress, giving you the chance to examine all the details and act accordingly.
+Click [here](https://clerk.com/docs/references/react/use-sign-in#use-sign-in-returns) to see the full list of properties returned.
 
 ## Usage
 
-Getting access to the [SignIn](https://clerk.com/docs/reference/clerkjs/signin) object from inside one of your components is easy. Note that the useSignIn composable can only be used if you installed the plugin.
+### Check the current state of a sign-in
 
-The following example accesses the `SignIn` object to check the current sign in attempt's status.
+Use the `useSignIn()` composable to check the current state of a sign-in.
 
 ```vue
 <script>
@@ -29,57 +25,12 @@ const { isLoaded, signIn } = useSignIn()
 
 <template>
   <div v-if="isLoaded">
-    The current sign in attempt status
-    is {{ signIn.status }}.
+    The current sign in attempt status is {{ signIn.status }}.
   </div>
+  <div v-else>Loading...</div>
 </template>
 ```
 
-A more involved example follows below. In this example, we show an approach to create your own custom form for signing in your users.
+### Create a custom sign-in flow
 
-```vue
-<script setup>
-import { ref } from 'vue'
-import { useSignIn } from 'vue-clerk'
-
-const { isLoaded, signIn, setActive } = useSignIn()
-
-const email = ref('')
-const password = ref('')
-
-async function submit() {
-  await signIn
-    .value
-    .create({
-      identifier: email.value,
-      password: password.value,
-    })
-    .then((result) => {
-      if (result.status === 'complete') {
-        console.log(result)
-        setActive({ session: result.createdSessionId })
-      }
-      else {
-        console.log(result)
-      }
-    })
-    .catch(err => console.error('error', err.errors[0].longMessage))
-}
-</script>
-
-<template>
-  <form v-if="isLoaded" @submit.prevent="submit">
-    <div>
-      <label for="email">Email</label>
-      <input v-model="email" type="email">
-    </div>
-    <div>
-      <label for="password">Password</label>
-      <input v-model="password" type="password">
-    </div>
-    <div>
-      <button>Sign in</button>
-    </div>
-  </form>
-</template>
-```
+The `useSignIn()` composable can also be used to build fully custom sign-in flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-in flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignIn()` composable to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).

--- a/docs/composables/use-sign-in.md
+++ b/docs/composables/use-sign-in.md
@@ -27,7 +27,9 @@ const { isLoaded, signIn } = useSignIn()
   <div v-if="isLoaded">
     The current sign in attempt status is {{ signIn.status }}.
   </div>
-  <div v-else>Loading...</div>
+  <div v-else>
+    Loading...
+  </div>
 </template>
 ```
 

--- a/docs/composables/use-sign-up.md
+++ b/docs/composables/use-sign-up.md
@@ -4,82 +4,33 @@ outline: deep
 
 # useSignUp()
 
-Access the SignUp object inside your components.
+The `useSignUp()` composable gives you access to the [`SignUp`](https://clerk.com/docs/references/javascript/sign-up/sign-up) object, which allows you to check the current state of a sign-up. This is also useful for creating a custom sign-up flow.
 
-## Overview
+## Returns
 
-The `useSignUp` composable gives you access to the [SignUp](https://clerk.com/docs/reference/clerkjs/signup) object inside your components.
-
-You can use the methods of the `SignUp` object to create your own custom sign up flow, as an alternative to using Clerk's pre-built [<SignUp/>](/authentication/sign-up.html) component.
-
-The `SignUp` object will also contain the state of the sign up attempt that is currently in progress, giving you the chance to examine all the details and act accordingly.
+Click [here](https://clerk.com/docs/references/react/use-sign-up#use-sign-up-returns) to see the full list of properties returned.
 
 ## Usage
 
-Getting access to the [SignUp](https://clerk.com/docs/reference/clerkjs/signup) object from inside one of your components is easy. Note that the `useSignUp` composable can only be used if you installed the plugin.
+### Check the current state of a up
 
-The following example accesses the `SignUp` object to check the current sign up attempt's status.
+Use the `useSignUp()` composable to check the current state of a sign-up.
 
 ```vue
-<script setup>
-import { useSignUp } from 'vue-clerk'
+<script>
+import { useSignIn } from 'vue-clerk'
 
-const { isLoaded, signUp } = useSignUp()
+const { isLoaded, signUp } = useSignIn()
 </script>
 
 <template>
   <div v-if="isLoaded">
-    The current sign up attempt status
-    is {{ signUp.status }}.
+    The current sign-up attempt status is {{ signUp.status }}.
   </div>
+  <div v-else>Loading...</div>
 </template>
 ```
 
-A more involved example follows below. In this example, we show an approach to create your own custom form for registering users.
+### Create a custom sign-up flow
 
-```vue
-<script setup>
-import { ref } from 'vue'
-import { useSignUp } from 'vue-clerk'
-
-const { isLoaded, signUp, setActive } = useSignUp()
-
-const email = ref('')
-const password = ref('')
-
-async function submit() {
-  await signUp
-    .value
-    .create({
-      emailAddress: email.value,
-      password: password.value,
-    })
-    .then((result) => {
-      if (result.status === 'complete') {
-        console.log(result)
-        setActive({ session: result.createdSessionId })
-      }
-      else {
-        console.log(result)
-      }
-    })
-    .catch(err => console.error('error', err.errors[0].longMessage))
-}
-</script>
-
-<template>
-  <form v-if="isLoaded" @submit.prevent="submit">
-    <div>
-      <label for="email">Email</label>
-      <input v-model="email" type="email">
-    </div>
-    <div>
-      <label for="password">Password</label>
-      <input v-model="password" type="password">
-    </div>
-    <div>
-      <button>Sign Up</button>
-    </div>
-  </form>
-</template>
-```
+The `useSignUp()` composable can also be used to build fully custom sign-up flows, if Clerk's pre-built components don't meet your specific needs or if you require more control over the authentication flow. Different sign-up flows include email and password, email and phone codes, email links, and multifactor (MFA). To learn more about using the `useSignUp()` composable to create custom flows, check out the [custom flow guides](https://clerk.com/docs/custom-flows/overview).

--- a/docs/composables/use-sign-up.md
+++ b/docs/composables/use-sign-up.md
@@ -27,7 +27,9 @@ const { isLoaded, signUp } = useSignIn()
   <div v-if="isLoaded">
     The current sign-up attempt status is {{ signUp.status }}.
   </div>
-  <div v-else>Loading...</div>
+  <div v-else>
+    Loading...
+  </div>
 </template>
 ```
 

--- a/docs/composables/use-user.md
+++ b/docs/composables/use-user.md
@@ -4,15 +4,19 @@ outline: deep
 
 # useUser()
 
-Access the User object inside of your component
+The `useUser()` composable is a convenient way to access the current [`User`](https://clerk.com/docs/references/javascript/user/user) data where you need it. This composable provides the user data and helper methods to manage the current active session.
 
-## Overview
+## Returns
 
-The useUser composable returns the current user state: `{ isLoaded, isSignedIn, user }`. You can use the `user` object to access the currently active [User](https://clerk.com/docs/reference/clerkjs/user). It can be used to update the user or display information about the user's profile, like their name or email address.
+Click [here](https://clerk.com/docs/references/react/use-user#use-user-returns) to see the full list of properties returned.
 
 ## Usage
 
-### Retrieve user data
+### Retrieve the current user data
+
+The following example demonstrates how to use the `useUser()` composable to access the `user` object, which includes the current user's data, like the user's full name. The `isLoaded` and `isSignedIn` properties are used to handle the loading state and to check if the user is signed in, respectively.
+
+For more information on the `User` object, see the [reference](https://clerk.com/docs/references/javascript/user/user).
 
 ```vue
 <script setup>
@@ -22,13 +26,19 @@ const { isLoaded, isSignedIn, user } = useUser()
 </script>
 
 <template>
-  <div v-if="isLoaded && isSignedIn">
-    Hello, {{ user.firstName }} welcome to Clerk
+  <div v-if="!isLoaded">
+    Loading...
+  </div>
+  <div v-else-if="!isSignedIn">
+    Not signed in
+  </div>
+  <div v-else>
+    Hello, {{ user.fullName }}!
   </div>
 </template>
 ```
 
-### Update user data
+### Update the current user data
 
 ```vue
 <script setup>
@@ -57,7 +67,9 @@ async function updateUser() {
 
 ### Reload user data
 
-In some circumstances you need retrieve the latest user data after updating your user in your backend. You can use `user.reload()` to reload the data on the frontend.
+To retrieve the latest user data after updating the user elsewhere, use the `user.reload()` method.
+
+For more information on the `reload()` method, see the [`User`](https://clerk.com/docs/references/javascript/user/user#reload) reference.
 
 ```vue
 <script setup>
@@ -68,9 +80,12 @@ const { user } = useUser()
 async function updateUser() {
   // updated data via an api point
   const updateMeta = await fetch('/api/updateMetadata')
+
+  // Check if the update was successful
   if (!updateMeta.message === 'success')
     throw new Error('Error updating')
 
+  // If the update was successful, reload the user data
   user.value.reload()
 }
 </script>
@@ -84,37 +99,3 @@ async function updateUser() {
   </div>
 </template>
 ```
-
-## Alternatives
-
-There are times where using a composable might be inconvenient. For such cases, there are alternative ways to get access to the [User](https://clerk.com/docs/reference/clerkjs/user) object.
-
-Vue Clerk provides the `<WithUser/>` component that will allow your wrapped components to get access to the currently signed in user.
-
-```vue
-<script>
-import { WithUser } from 'vue-clerk'
-
-export default {
-  components: { WithUser }
-}
-</script>
-
-<template>
-  <WithUser v-slot="{ user }">
-    {{ user?.firstName ? `Hello, ${user.firstName}` : 'Hello there!' }}
-  </WithUser>
-</template>
-```
-
-## Props
-
-|Name|Type|Description|
-|--- |--- |--- |
-|userId|`string`|The ID of the active user, or null when signed out. In data-loaders, this is often the only piece of information needed to securely retrieve the data associated with a request.|
-|sessionId|`string`|The ID of the active session, or null when signed out. This is primarily used in audit logs to enable device-level granularity instead of user-level.|
-|actor|`string`|If user impersonation is being used, this field will contain information about the impersonator.|
-|getToken({ template?: string; })|`string`|Retrieves a signed JWT that is structured according to the corresponding JWT template in your dashboard. If no template parameter is provided, a default Clerk session JWT is returned.|
-|orgId|`string`|A unique identifier for this organization.|
-|orgRole|`string`|The role that the user will have in the organization. Valid values are admin and basic_member|
-|claims|`object`|All claims for the JWT associated with the current user|

--- a/docs/control/clerk-loaded.md
+++ b/docs/control/clerk-loaded.md
@@ -4,7 +4,7 @@ outline: deep
 
 # `<ClerkLoaded />`
 
-The `<ClerkLoaded>` component guarantees that the [Clerk](https://clerk.com/docs/reference/clerkjs/clerk) object has loaded before rendering its children.
+The `<ClerkLoaded>` component guarantees that the Clerk object has loaded and will be available under `window.Clerk`. This allows you to wrap child components to access the `Clerk` object without the need to check it exists.
 
 ## Usage
 
@@ -21,13 +21,12 @@ import { ClerkLoaded } from 'vue-clerk'
 ```
 
 ```vue
-<script>
-export default {
-  name: 'Page',
-  mounted() {
-    document.title = this.$clerk.version
-  }
-}
+<script setup>
+import { onMounted } from 'vue'
+
+onMounted(() => {
+  document.title = 'This page uses Clerk ' + window.Clerk.version
+})
 </script>
 
 <template>

--- a/docs/control/clerk-loaded.md
+++ b/docs/control/clerk-loaded.md
@@ -25,7 +25,7 @@ import { ClerkLoaded } from 'vue-clerk'
 import { onMounted } from 'vue'
 
 onMounted(() => {
-  document.title = 'This page uses Clerk ' + window.Clerk.version
+  document.title = `This page uses Clerk ${window.Clerk.version}`
 })
 </script>
 

--- a/docs/control/protect.md
+++ b/docs/control/protect.md
@@ -71,7 +71,7 @@ import { Protect } from 'vue-clerk'
 </script>
 
 <template>
-  <Protect :condition="(has) => has({role: 'org:admin'}) || has({role: 'org:billing_manager'})">
+  <Protect :condition="(has) => has({ role: 'org:admin' }) || has({ role: 'org:billing_manager' })">
     <template #fallback>
       <p>Only an Admin or Billing Manager can access this content.</p>
     </template>

--- a/docs/control/protect.md
+++ b/docs/control/protect.md
@@ -6,13 +6,23 @@ outline: deep
 
 The `<Protect>` component is used for authorization. It only renders its children when the current user has the specified permission or role in the organization.
 
+## Props
+
+Click [here](https://clerk.com/docs/components/protect#properties) to see the full list of props available.
+
+## Slots
+
+|Name|Description|
+|:---:|:---:|
+|`fallback?`|An optional element to show when a user doesn't have the `role` or `permission` to access the protected content.|
+
 ## Usage
 
 To limit who is able to see the content that `<Protect>` renders, you can pass either the `permission` or `role` prop. The recommended approach is to use `permission` because this lets you modify roles without breaking your application. Permissions can be assigned to different roles with ease.
 
 If you do not pass either prop, `<Protect>` behaves the same as `<SignedIn>` and will render its children if the user is signed in, regardless of their role or its permissions.
 
-For more complex authorization logic, pass conditional logic to the `condition` prop.
+For more complex authorization logic, [pass conditional logic to the `condition` prop](https://clerk.com/docs/components/protect#render-content-conditionally).
 
 ### Render content by permissions
 
@@ -28,14 +38,14 @@ import { Protect } from 'vue-clerk'
     <template #fallback>
       <p>You do not have the permissions to create an invoice.</p>
     </template>
-    <p>Visible content to users with the said permission.</p>
+    <p>Visible content.</p>
   </Protect>
 </template>
 ```
 
 ### Render content by role
 
-While authorization by permission is recommended, for convenience, `<Protect>` allows a role prop to be passed. The children of the following component will only be visible to users with the `org:billing` role.
+While authorization by `permission` is recommended, for convenience, `<Protect>` allows a `role` prop to be passed. The children of the following component will only be visible to users with the `org:billing` role.
 
 ```vue
 <script setup>
@@ -43,29 +53,29 @@ import { Protect } from 'vue-clerk'
 </script>
 
 <template>
-  <Protect permission="org:billing">
+  <Protect role="org:billing">
     <template #fallback>
       <p>Only a member of the Billing department can access this content.</p>
     </template>
-    <p>Visible content to the Billing department.</p>
+    <p>Visible content.</p>
   </Protect>
 </template>
 ```
 
-## Props
+### Render content conditionally
+The following example uses `<Protect>`'s condition prop to conditionally render its children if the user has the correct role.
 
-|Name|Type|Description|
-|:---:|:---:|:---:|
-|`condition?`|`has => boolean`|Optional conditional logic that renders the children if it returns `true`.|
-|`permission?`|`string`|Optional string corresponding to a Role's Permission in the format `org:<resource>:<action>`|
-|`role?`|`string`|Optional string corresponding to an Organization's Role in the format `org:<role>`|
+```vue
+<script setup>
+import { Protect } from 'vue-clerk'
+</script>
 
-:::warning
-`<Protect>` can only accept `permission` or `role`, not both. The recommended approach is to use `permission`.
-:::
-
-## Slots
-
-|Name|Description|
-|:---:|:---:|
-|`fallback?`|An optional element to show when a user doesn't have the `role` or `permission` to access the protected content.|
+<template>
+  <Protect :condition="(has) => has({role: 'org:admin'}) || has({role: 'org:billing_manager'})">
+    <template #fallback>
+      <p>Only an Admin or Billing Manager can access this content.</p>
+    </template>
+    <p>Visible content.</p>
+  </Protect>
+</template>
+```

--- a/docs/control/redirect-to-signin.md
+++ b/docs/control/redirect-to-signin.md
@@ -6,6 +6,10 @@ outline: deep
 
 The `<RedirectToSignIn />` component will navigate to the sign in URL which has been configured in your application instance. The behavior will be just like a server-side (3xx) redirect, and will override the current location in the history stack.
 
+## Props
+
+Click [here](https://clerk.com/docs/components/control/redirect-to-signin#properties) to see the full list of props available.
+
 ## Usage
 
 ```vue
@@ -23,11 +27,3 @@ import { RedirectToSignIn, SignedIn, SignedOut } from 'vue-clerk'
   </SignedOut>
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`signInFallbackRedirectUrl?`|`string`|The fallback URL to redirect to after the user signs in, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](https://clerk.com/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.|
-|`signInForceRedirectUrl`|`string`|If provided, this URL will always be redirected to after the user signs in. It's recommended to use [the environment variable instead](https://clerk.com/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects).|
-|`initialValues`|[`SignInInitialValues`](https://clerk.com/docs/references/javascript/types/sign-in-initial-values)|The values used to prefill the sign-in fields with.|

--- a/docs/control/redirect-to-signup.md
+++ b/docs/control/redirect-to-signup.md
@@ -6,6 +6,10 @@ outline: deep
 
 The `<RedirectToSignUp />` component will navigate to the sign up URL which has been configured in your application instance. The behavior will be just like a server-side (3xx) redirect, and will override the current location in the history stack.
 
+## Props
+
+Click [here](https://clerk.com/docs/components/control/redirect-to-signup#properties) to see the full list of props available.
+
 ## Usage
 
 ```vue
@@ -22,11 +26,3 @@ import { RedirectToSignUp, SignedIn, SignedOut } from 'vue-clerk'
   </SignedOut>
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`signInFallbackRedirectUrl?`|`string`|The fallback URL to redirect to after the user signs up, if there's no `redirect_url` in the path already. Defaults to `/`. It's recommended to use [the environment variable](https://clerk.com/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects) instead.|
-|`signInForceRedirectUrl`|`string`|If provided, this URL will always be redirected to after the user signs up. It's recommended to use [the environment variable instead](https://clerk.com/docs/deployments/clerk-environment-variables#sign-in-and-sign-up-redirects).|
-|`initialValues`|[`SignInInitialValues`](https://clerk.com/docs/references/javascript/types/sign-in-initial-values)|The values used to prefill the sign-in fields with.|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,6 +6,10 @@ outline: deep
 
 Learn how to make Vue Clerk components available in your project.
 
+::: info
+To reduce the time of going back and forth between the official [Clerk docs](https://clerk.com/docs) and the Vue Clerk docs, we have copied most of the content you will see here from the Clerk docs and added some Vue-specific information.
+:::
+
 ## Overview
 
 Vue Clerk is a wrapper around ClerkJS. It's a way to integrate Clerk into your Vue application.

--- a/docs/organization/create-organization.md
+++ b/docs/organization/create-organization.md
@@ -9,6 +9,10 @@ outline: deep
 
 The `<CreateOrganization />` component is used to render an organization creation UI that allows users to create brand new organizations within your application.
 
+## Props
+
+Click [here](https://clerk.com/docs/components/organization/create-organization#properties) to see the full list of props available.
+
 ## Usage
 
 ```vue
@@ -20,12 +24,3 @@ import { CreateOrganization } from 'vue-clerk'
   <CreateOrganization />
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`afterCreateOrganizationUrl`|`string`|Full URL or path to navigate after creating a new organization.|
-|`routing`|`'hash' \|'path' \|'virtual'`|The routing strategy for your pages.|
-|`path`|`string`|The path where the component is mounted when path-based routing is used. -e.g. /create-org. This prop is ignored in hash and virtual based routing.|
-|`appearance`|[`Appearance`](https://clerk.com/docs/components/customization/overview) / `undefined`|Optional object to style your components. Will only affect Clerk Components and not [Account Portal](https://clerk.com/docs/account-portal/overview) pages.|

--- a/docs/organization/organization-list.md
+++ b/docs/organization/organization-list.md
@@ -9,6 +9,10 @@ outline: deep
 
 The `<OrganizationList />` component is used to display organization related memberships, invitations, and suggestions for the user.
 
+## Props
+
+Click [here](https://clerk.com/docs/components/organization/organization-list#properties) to see the full list of props available.
+
 ## Usage
 
 ```vue
@@ -34,14 +38,3 @@ If you would like to prohibit people from using their personal accounts and forc
   <OrganizationList hide-personal />
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`hidePersonal`|`boolean`|By default, users can switch between organization and their personal account. This option controls whether `<OrganizationList />` will include the user's personal account in the organization list. Setting this to `false` will hide the personal account entry, and users will only be able to switch between organizations. Defaults to `false`.|
-|`skipInvitationScreen`|`boolean` \|`undefined`|Hides the screen for sending invitations after an organization is created. When left undefined Clerk will automatically hide the screen if the number of max allowed members is equal to 1.Defaults to `false`.|
-|`appearance`|[`Appearance`](https://clerk.com/docs/components/customization/overview) \| `undefined`|Optional object to style your components. Will only affect Clerk Components and not [Account Portal](https://clerk.com/docs/account-portal/overview) pages.|
-|`afterCreateOrganizationUrl`|`((org: Organization) => string)` \|`string`|Full URL or path to navigate after creating a new organization.|
-|`afterSelectOrganizationUrl`|`((org: Organization) => string)` \|`string`|Full URL or path to navigate after selecting an organization.Defaults to `undefined`.|
-|`afterSelectPersonalUrl`|`((org: Organization) => string)` \|`string`|Full URL or path to navigate after selecting the personal account.Defaults to `undefined`.|

--- a/docs/organization/organization-profile.md
+++ b/docs/organization/organization-profile.md
@@ -9,6 +9,14 @@ outline: deep
 
 The `<OrganizationProfile />` component is used to render a beautiful, full-featured organization management UI that allows users to manage their organization profile and security settings.
 
+Out of the box, this component's General tab displays the organization's information and the Leave organization button. Admins will be able to see the Update profile button, Verified domains section, and Delete organization button.
+
+The Members tab shows the organization's members along with their join dates and roles. Admins will have the ability to invite a member, change a member's role, or remove them from the organization. Admins will have tabs within the Members tab to view the organization's [invitations](https://clerk.com/docs/organizations/overview#organization-invitations) and [requests](https://clerk.com/docs/organizations/overview#membership-requests).
+
+## Props
+
+Click [here](https://clerk.com/docs/components/organization/organization-profile#properties) to see the full list of props available.
+
 ## Usage
 
 ```vue
@@ -17,15 +25,6 @@ import { OrganizationProfile } from 'vue-clerk'
 </script>
 
 <template>
-  <OrganizationProfile />
+  <OrganizationProfile path="/organization-profile" />
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`afterLeaveOrganizationUrl`|`string`|Full URL or path to navigate after leaving an organization.|
-|`routing`|`'hash' \|'path' \|'virtual'`|The routing strategy for your pages.|
-|`path`|`string`|The path where the component is mounted when path-based routing is used. -e.g. /create-org. This prop is ignored in hash and virtual based routing.|
-|`appearance`|[`Appearance`](https://clerk.com/docs/components/customization/overview) \| `undefined`|Optional object to style your components. Will only affect Clerk Components and not [Account Portal](https://clerk.com/docs/account-portal/overview) pages.|

--- a/docs/organization/organization-switcher.md
+++ b/docs/organization/organization-switcher.md
@@ -7,7 +7,13 @@ outline: deep
 <br />
 <img src="https://clerk.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2F_docs%2Fmain%2Fui-components%2Forganization-switcher.svg&w=1080&q=75" />
 
-The `<OrganizationSwitcher />` component is used to enable the ability to switch between available organizations the user may be part of in your application.
+The `<OrganizationSwitcher />` component allows a user to switch between their account types - their personal account and their joined organizations. This component is useful for applications that have a multi-tenant architecture, where users can be part of multiple organizations.
+
+Out of the box, this component will show notifications to the user if they have organization [invitations](https://clerk.com/docs/organizations/overview#organization-invitations) or [suggestions](https://clerk.com/docs/organizations/overview#suggestions). Admins will be able to see notifications for [requests](https://clerk.com/docs/organizations/overview#membership-requests) to join an organization.
+
+## Props
+
+Click [here](https://clerk.com/docs/components/organization/organization-switcher#properties) to see the full list of props available.
 
 ## Usage
 
@@ -20,19 +26,3 @@ import { OrganizationSwitcher } from 'vue-clerk'
   <OrganizationSwitcher />
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`afterCreateOrganizationUrl`|`string`|Full URL or path to navigate after creating a new organization.|
-|`appearance`|[`Appearance`](https://clerk.com/docs/components/customization/overview) \| `undefined`|Optional object to style your components. Will only affect Clerk Components and not [Account Portal](https://clerk.com/docs/account-portal/overview) pages.|
-|`createOrganizationUrl`|`string`|Full URL or path where the [`<CreateOrganization />`](/organization/create-organization) component is mounted.|
-|`organizationProfileUrl`|`string`|Full URL or path where the [`<OrganizationProfile />`](/organization/organization-profile) component is mounted.|
-|`createOrganizationMode`|`'modal' \|'navigation'`|Controls whether clicking the "Create organization" button will cause the [`<CreateOrganization />`](/organization/create-organization) component to open as a modal, or if the browser will navigate to the `createOrganizationUrl` where [`<CreateOrganization />`](/organization/create-organization) is mounted as a page.Defaults to: `'modal'`.|
-|`organizationProfileMode`|`'modal' \|'navigation'`|Controls whether clicking the "Manage organization" button will cause the [`<OrganizationProfile />`](/organization/organization-profile) component to open as a modal, or if the browser will navigate to the `organizationProfileUrl` where [`<OrganizationProfile />`](/organization/organization-profile) is mounted as a page.Defaults to: `'modal'`.|
-|`afterLeaveOrganizationUrl`|`string`|Full URL or path to navigate to after the user leaves the currently active organization.|
-|`afterSwitchOrganizationUrl`|`string`|Full URL or path to navigate after a successful organization switch.|
-|`hidePersonal`|`boolean`|By default, users can switch between organizations and their personal workspace. This option controls whether [`<OrganizationSwitcher />`](/organization/organization-switcher) will include the user's personal workspace in the organization list. Setting this to `true` will hide the personal workspace entry, and allow users to switch only between organizations.Defaults to: `false`.|
-|`defaultOpen`|`boolean`|Controls the default state of the [`<OrganizationSwitcher />`](/organization/organization-switcher) component.|
-|`organizationProfileProps`|`object`|Specify options for the underlying [`<OrganizationProfile />`](/organization/organization-profile) component.e.g. `{appearance: {...}}`|

--- a/docs/unstyled/sign-in-button.md
+++ b/docs/unstyled/sign-in-button.md
@@ -6,6 +6,16 @@ outline: deep
 
 The `<SignInButton>` component is a button that links to the sign-in page or displays the sign-in modal.
 
+## Props
+
+Click [here](https://clerk.com/docs/components/unstyled/sign-in-button#sign-in-button-properties) to see the full list of props available.
+
+## Slots
+
+|Name|Description|
+|:----|:----|
+|`default?`|children you want to wrap the `<SignInButton>` in.|
+
 ## Usage
 
 ### Basic Usage
@@ -40,18 +50,3 @@ import { SignInButton } from 'vue-clerk'
   </div>
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`redirectUrl`|`string`|Full URL or path to navigate after successful sign in or sign up. The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value.|
-|`afterSignInUrl`|`string`|The full URL or path to navigate after a successful sign in.|
-|`afterSignUpUrl`|`string`|The full URL or path to navigate after a successful sign up.|
-|`mode`|`'redirect' \|'modal'`|Determines what happens when a user clicks on the `<SignInButton>`. Setting this to `'redirect'` will redirect the user to the sign-in route. Setting this to `'modal'` will open a modal on the current route.Defaults to 'redirect'`|
-
-## Slots
-
-|Name|Description|
-|:----|:----|
-|`default?`|children you want to wrap the `<SignInButton>` in.|

--- a/docs/unstyled/sign-out-button.md
+++ b/docs/unstyled/sign-out-button.md
@@ -6,6 +6,16 @@ outline: deep
 
 The `<SignOutButton>` component is a button that signs a user out. By default, it is a `<button>` tag that says Sign Out, but it is completely customizable by passing children.
 
+## Props
+
+Click [here](https://clerk.com/docs/components/unstyled/sign-out-button#sign-out-button-properties) to see the full list of props available.
+
+## Slots
+
+|Name|Description|
+|:----|:----|
+|`default?`|children you want to wrap the `<SignOutButton>` in.|
+
 ## Usage
 
 ### Basic Usage
@@ -46,11 +56,17 @@ import { SignOutButton } from 'vue-clerk'
 
 ### Multi-session usage
 
+<br />
+
+#### Sign out of all sessions
+
+Clicking the `<SignOutButton>` component signs the user out of all sessions. This is the default behavior.
+
 #### Sign out of a specific session
 
 You can sign out of a specific session by passing in a `sessionId` to the `signOutOptions` prop. This is useful for signing a single account out of a multi-session (multiple account) application.
 
-In the example below, the `sessionId` is retrieved from the [`useAuth()`](/composables/use-auth) composable.
+In the example below, the `sessionId` is retrieved from the [`useAuth()`](/composables/use-auth) composable. If the user is not signed in, the `sessionId` will be `null`, and the user is shown the `<SignInButton>` component. If the user is signed in, the user is shown the `<SignOutButton>` component, which when clicked, signs the user out of that specific session.
 
 ```vue
 <script setup>
@@ -61,45 +77,8 @@ const { sessionId } = useAuth()
 
 <template>
   <div>
-    <h1>{{ sessionId ? 'Sign out' : 'Sign in' }}</h1>
-    <SignOutButton v-if="sessionId" :sign-out-options="{ sessionId }" />
-    <SignInButton v-else />
+    <SignInButton v-if="!sessionId" />
+    <SignOutButton v-else :sign-out-options="{ sessionId }" />
   </div>
 </template>
 ```
-
-Sign out of all sessions
-
-#### Sign out of all sessions
-
-You can sign out of all currently active sessions by passing a callback that returns the `signOut()` method to the signOutCallback prop. This is useful for signing out all currently active accounts from a multi-session (multiple account) application.
-
-In the example below, the `signOut()` method is retrieved from the [`useClerk()`](/composables/use-clerk) composable.
-
-```vue
-<script setup>
-import { SignOutButton, useClerk } from 'vue-clerk'
-
-const { signOut } = useClerk()
-</script>
-
-<template>
-  <div>
-    <h1>Sign out</h1>
-    <SignOutButton :sign-out-callback="signOut" />
-  </div>
-</template>
-```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`signOutCallback?`|`() => (void \|Promise<any>)`|A promise to handle after the sign out has successfully happened.|
-|`signOutOptions?`|`SignOutOptions`|Object that has a `sessionId` property. The `sessionId` can be passed in to sign out a specific session, which is useful for multisession applications.|
-
-## Slots
-
-|Name|Description|
-|:----|:----|
-|`default?`|children you want to wrap the `<SignOutButton>` in.|

--- a/docs/unstyled/sign-up-button.md
+++ b/docs/unstyled/sign-up-button.md
@@ -6,6 +6,16 @@ outline: deep
 
 The `<SignUpButton>` component is a button that links to the sign-up page or displays the sign-up modal.
 
+## Props
+
+Click [here](https://clerk.com/docs/components/unstyled/sign-up-button#sign-up-button-properties) to see the full list of props available.
+
+## Slots
+
+|Name|Description|
+|:----|:----|
+|`default?`|children you want to wrap the `<SignUpButton>` in.|
+
 ## Usage
 
 ### Basic Usage
@@ -43,18 +53,3 @@ import { SignUpButton } from 'vue-clerk'
   </div>
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`redirectUrl`|`string`|Full URL or path to navigate after successful sign in or sign up. The same as setting `afterSignInUrl` and `afterSignUpUrl` to the same value.|
-|`afterSignInUrl`|`string`|The full URL or path to navigate after a successful sign in.|
-|`afterSignUpUrl`|`string`|The full URL or path to navigate after a successful sign up.|
-|`mode`|`'redirect' \|'modal'`|Determines what happens when a user clicks on the `<SignInButton>`. Setting this to `'redirect'` will redirect the user to the sign-in route. Setting this to `'modal'` will open a modal on the current route.Defaults to 'redirect'`|
-
-## Slots
-
-|Name|Description|
-|:----|:----|
-|`default?`|children you want to wrap the `<SignUpButton>` in.|

--- a/docs/user/user-button.md
+++ b/docs/user/user-button.md
@@ -11,20 +11,28 @@ The `<UserButton />` component is used to render the familiar user button UI pop
 
 Clerk is the only provider with multi-session support, allowing users to sign into multiple accounts at once and switch between them. For multisession apps, the `<UserButton />` automatically supports instant account switching, without the need of a full page reload. For more information, you can check out the [Multi-session applications guide](https://clerk.com/docs/custom-flows/multi-session-applications#overview).
 
+## Props
+
+Click [here](https://clerk.com/docs/components/user/user-button#properties) to see the full list of props available.
+
 ## Usage
+
+In the following example, `<UserButton />` is mounted inside a header component, which is a common pattern on many websites and applications. When the user is signed in, they will see their avatar and be able to open the popup menu.
 
 ```vue
 <script setup>
-import { SignInButton, UserButton, useAuth } from 'vue-clerk'
-
-const { isSignedIn } = useAuth()
+import { SignedIn, SignedOut, SignInButton, UserButton } from 'vue-clerk'
 </script>
 
 <template>
   <header>
     <h1>My App</h1>
-    <UserButton v-if="isSignedIn" />
-    <SignInButton v-else />
+    <SignedIn>
+      <UserButton />
+    </SignedIn>
+    <SignedOut>
+      <SignInButton />
+    </SignedOut>
   </header>
 </template>
 
@@ -36,22 +44,3 @@ header {
 }
 </style>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`appearance`|[`Appearance`](https://clerk.com/docs/components/customization/overview) / `undefined`|Optional object to style your components. Will only affect Clerk Components and not [Account Portal](https://clerk.com/docs/account-portal/overview) pages.|
-|`showName`|`boolean`|Controls if the user name is displayed next to the user image button.|
-|`signInUrl`|`string`|The full URL or path to navigate to when the "Add another account" button is clicked.|
-|`userProfileMode`|`'modal' \|'navigation'`|Controls whether clicking the "Manage your account" button will cause the [`<UserProfile />`](/user/user-profile) component to open as a modal, or if the browser will navigate to the `userProfileUrl` where [`<UserProfile />`](/user/user-profile) is mounted as a page.Defaults to: `'modal'`.|
-|`userProfileUrl`|`string`|The full URL or path leading to the user management interface.|
-|`afterSignOutUrl`|`string`|The full URL or path to navigate to after a signing out from all accounts (applies to both single-session and multi-session apps).|
-|`afterMultiSessionSingleSignOutUrl`|`string`|The full URL or path to navigate to after a signing out from currently active account (multisession apps).|
-|`afterSwitchSessionUrl`|`string`|The full URL or path to navigate to after a successful account change (multi-session apps).|
-|`defaultOpen`|`boolean`|Controls whether the `<UserButton />` should open by default during the first render.|
-|`userProfileProps`|`object`|Specify options for the underlying [`<UserProfile />`](/user/user-profile) component. e.g. `{additionalOAuthScopes: {google: ['foo', 'bar'], github: ['qux']}}`.|
-
-## Customization
-
-The `<UserButton/>` component can be highly customized through the [appearance prop](https://clerk.com/docs/component-customization/appearance-prop).

--- a/docs/user/user-button.md
+++ b/docs/user/user-button.md
@@ -21,7 +21,7 @@ In the following example, `<UserButton />` is mounted inside a header component,
 
 ```vue
 <script setup>
-import { SignedIn, SignedOut, SignInButton, UserButton } from 'vue-clerk'
+import { SignInButton, SignedIn, SignedOut, UserButton } from 'vue-clerk'
 </script>
 
 <template>

--- a/docs/user/user-profile.md
+++ b/docs/user/user-profile.md
@@ -9,25 +9,18 @@ outline: deep
 
 The `<UserProfile />` component is used to render a beautiful, full-featured account management UI that allows users to manage their profile and security settings.
 
+## Props
+
+Click [here](https://clerk.com/docs/components/user/user-profile#properties) to see the full list of props available.
+
 ## Usage
 
 ```vue
 <script setup>
-import { UserProfile, useAuth } from 'vue-clerk'
-
-const { isSignedIn } = useAuth()
+import { UserProfile } from 'vue-clerk'
 </script>
 
 <template>
-  <UserProfile path="/user-profile" routing="path" />
+  <UserProfile path="/user-profile" />
 </template>
 ```
-
-## Props
-
-|Name|Type|Description|
-|:----|:----|:----|
-|`appearance`|[`Appearance`](https://clerk.com/docs/components/customization/overview) / `undefined`|Optional object to style your components. Will only affect Clerk Components and not [Account Portal](https://clerk.com/docs/account-portal/overview) pages.|
-|`routing`|`'hash' \|'path' \|'virtual'`|The routing strategy for your pages.|
-|`path`|`string`|The path where the component is mounted on when path-based routing is used e.g. /sign-in.|
-|`additionalOAuthScopes`|`object`|Specify additional scopes per OAuth provider that your users would like to provide if not already approved. e.g. `{google: ['foo', 'bar'], github: ['qux']}`.|


### PR DESCRIPTION
This PR removes the properties from each component page and adds a link instead that redirects to the React props section