### PR TITLE
feat: Add custom menu items to UserButton component

### DIFF
--- a/.changeset/kind-carrots-occur.md
+++ b/.changeset/kind-carrots-occur.md
@@ -1,0 +1,5 @@
+---
+"vue-clerk": patch
+---
+
+feat: Add custom menu items to UserButton component

--- a/.changeset/kind-carrots-occur.md
+++ b/.changeset/kind-carrots-occur.md
@@ -3,3 +3,22 @@
 ---
 
 feat: Add custom menu items to UserButton component
+
+Usage:
+
+```vue
+<template>
+  <UserButton>
+    <UserButton.Link label="Terms" href="/terms">
+      <template #labelIcon>
+        <TermsIcon />
+      </template>
+    </UserButton.Link>
+    <UserButton.Action label="Chat Modal" @click="openChat">
+      <template #labelIcon>
+        <ChatIcon />
+      </template>
+    </UserButton.Action>
+  </UserButton>
+</template>
+```

--- a/playground/components/CustomUserButton.vue
+++ b/playground/components/CustomUserButton.vue
@@ -1,28 +1,27 @@
 <script setup lang="ts">
 import { UserButton } from 'vue-clerk'
-import type { CustomMenuItem } from '@clerk/types'
 
-const customMenuItemIcon = ref<HTMLDivElement | null>(null)
-const customMenuItems: CustomMenuItem[] = [
-  {
-    label: 'Open chat',
-    mountIcon: (el) => {
-      customMenuItemIcon.value = el
-    },
-    unmountIcon: () => { /* cleanup */ },
-    onClick: () => {
-      // eslint-disable-next-line no-alert
-      alert('init chat')
-    },
-  },
-]
+function openChatModal() {
+  // eslint-disable-next-line no-console
+  console.log('openChatModal')
+}
 </script>
 
 <template>
-  <UserButton :custom-menu-items="customMenuItems" />
-  <Teleport v-if="customMenuItemIcon" :to="customMenuItemIcon">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-      <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-    </svg>
-  </Teleport>
+  <UserButton>
+    <UserButton.Link label="Terms" href="/custom-pages">
+      <template #labelIcon>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      </template>
+    </UserButton.Link>
+    <UserButton.Action label="Chat Modal" @click="openChatModal">
+      <template #labelIcon>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+        </svg>
+      </template>
+    </userbutton.action>
+  </UserButton>
 </template>

--- a/src/components/UserButton.ts
+++ b/src/components/UserButton.ts
@@ -1,0 +1,95 @@
+import type { Component } from 'vue'
+import { Teleport, computed, defineComponent, h, ref, watchEffect } from 'vue'
+import type { CustomMenuItem, UserButtonProps } from '@clerk/types'
+import { useClerk } from '../composables/useClerk'
+import { ClerkLoaded } from './controlComponents'
+
+export const UserButtonMain = defineComponent((props: UserButtonProps, { slots }) => {
+  const clerk = useClerk()
+  const el = ref<HTMLDivElement | null>(null)
+  const mountRefs = ref<Map<Component, HTMLDivElement>>(new Map())
+
+  const menuSlotItems = slots.default?.()
+
+  const customMenuItems = computed<CustomMenuItem[]>(() => {
+    return menuSlotItems?.map((item) => {
+      const menuItem: CustomMenuItem = {
+        label: item.props?.label ?? '',
+      }
+
+      if (item.props?.href) {
+        menuItem.href = item.props.href
+      }
+
+      if (item.props?.onClick) {
+        menuItem.onClick = item.props.onClick
+      }
+
+      return {
+        ...menuItem,
+        mountIcon(el) {
+          mountRefs.value.set(item, el)
+        },
+        // TODO: What do we need to clean?
+        unmountIcon: () => { /* cleanup */ },
+      }
+    }) ?? []
+  })
+
+  watchEffect((onInvalidate) => {
+    if (el.value) {
+      clerk.mountUserButton(el.value, {
+        ...props,
+        customMenuItems: customMenuItems.value,
+      })
+    }
+
+    onInvalidate(() => {
+      if (el.value)
+        clerk.unmountUserButton(el.value)
+    })
+  })
+
+  return () => h(ClerkLoaded, () => [
+    h('div', { ref: el }),
+    ...(menuSlotItems?.map((item) => {
+      return mountRefs.value.get(item) ? h(Teleport, { to: mountRefs.value.get(item) }, item) : null
+    }) ?? []),
+  ])
+})
+
+const UserButtonLink = defineComponent({
+  inheritAttrs: false,
+  props: {
+    label: {
+      type: String,
+      required: true,
+    },
+    href: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(_props, { slots }) {
+    return () => slots.labelIcon?.()
+  },
+})
+
+const UserButtonAction = defineComponent({
+  inheritAttrs: false,
+  props: {
+    label: {
+      type: String,
+      required: true,
+    },
+    onClick: {
+      type: Function,
+      required: true,
+    },
+  },
+  setup(_props, { slots }) {
+    return () => slots.labelIcon?.()
+  },
+})
+
+export const UserButton = Object.assign(UserButtonMain, { Link: UserButtonLink, Action: UserButtonAction })

--- a/src/components/UserButton.ts
+++ b/src/components/UserButton.ts
@@ -7,7 +7,7 @@ import { ClerkLoaded } from './controlComponents'
 const UserButtonRoot = defineComponent((props: UserButtonProps, { slots }) => {
   const clerk = useClerk()
   const el = ref<HTMLDivElement | null>(null)
-  const teleportLocationMap = ref<Map<Component, HTMLDivElement>>(new Map())
+  const teleportDestinationMap = ref<Map<Component, HTMLDivElement>>(new Map())
 
   const menuSlotItems = slots.default?.()
 
@@ -28,7 +28,7 @@ const UserButtonRoot = defineComponent((props: UserButtonProps, { slots }) => {
       return {
         ...menuItem,
         mountIcon(el) {
-          teleportLocationMap.value.set(item, el)
+          teleportDestinationMap.value.set(item, el)
         },
         // TODO: What do we need to clean?
         unmountIcon: () => { /* cleanup */ },
@@ -53,7 +53,7 @@ const UserButtonRoot = defineComponent((props: UserButtonProps, { slots }) => {
   return () => h(ClerkLoaded, () => [
     h('div', { ref: el }),
     ...menuSlotItems?.map((item) => {
-      const target = teleportLocationMap.value.get(item)
+      const target = teleportDestinationMap.value.get(item)
       return target ? h(Teleport, { to: target }, item) : null
     }) ?? [],
   ])

--- a/src/components/UserButton.ts
+++ b/src/components/UserButton.ts
@@ -4,10 +4,10 @@ import type { CustomMenuItem, UserButtonProps } from '@clerk/types'
 import { useClerk } from '../composables/useClerk'
 import { ClerkLoaded } from './controlComponents'
 
-export const UserButtonMain = defineComponent((props: UserButtonProps, { slots }) => {
+const UserButtonRoot = defineComponent((props: UserButtonProps, { slots }) => {
   const clerk = useClerk()
   const el = ref<HTMLDivElement | null>(null)
-  const mountRefs = ref<Map<Component, HTMLDivElement>>(new Map())
+  const teleportLocationMap = ref<Map<Component, HTMLDivElement>>(new Map())
 
   const menuSlotItems = slots.default?.()
 
@@ -28,7 +28,7 @@ export const UserButtonMain = defineComponent((props: UserButtonProps, { slots }
       return {
         ...menuItem,
         mountIcon(el) {
-          mountRefs.value.set(item, el)
+          teleportLocationMap.value.set(item, el)
         },
         // TODO: What do we need to clean?
         unmountIcon: () => { /* cleanup */ },
@@ -53,7 +53,7 @@ export const UserButtonMain = defineComponent((props: UserButtonProps, { slots }
   return () => h(ClerkLoaded, () => [
     h('div', { ref: el }),
     ...(menuSlotItems?.map((item) => {
-      return mountRefs.value.get(item) ? h(Teleport, { to: mountRefs.value.get(item) }, item) : null
+      return teleportLocationMap.value.get(item) ? h(Teleport, { to: teleportLocationMap.value.get(item) }, item) : null
     }) ?? []),
   ])
 })
@@ -92,4 +92,4 @@ const UserButtonAction = defineComponent({
   },
 })
 
-export const UserButton = Object.assign(UserButtonMain, { Link: UserButtonLink, Action: UserButtonAction })
+export const UserButton = Object.assign(UserButtonRoot, { Link: UserButtonLink, Action: UserButtonAction })

--- a/src/components/UserButton.ts
+++ b/src/components/UserButton.ts
@@ -1,4 +1,4 @@
-import type { Component } from 'vue'
+import type { Component, PropType } from 'vue'
 import { Teleport, computed, defineComponent, h, ref, watchEffect } from 'vue'
 import type { CustomMenuItem, UserButtonProps } from '@clerk/types'
 import { useClerk } from '../composables/useClerk'
@@ -52,9 +52,10 @@ const UserButtonRoot = defineComponent((props: UserButtonProps, { slots }) => {
 
   return () => h(ClerkLoaded, () => [
     h('div', { ref: el }),
-    ...(menuSlotItems?.map((item) => {
-      return teleportLocationMap.value.get(item) ? h(Teleport, { to: teleportLocationMap.value.get(item) }, item) : null
-    }) ?? []),
+    ...menuSlotItems?.map((item) => {
+      const target = teleportLocationMap.value.get(item)
+      return target ? h(Teleport, { to: target }, item) : null
+    }) ?? [],
   ])
 })
 
@@ -83,7 +84,7 @@ const UserButtonAction = defineComponent({
       required: true,
     },
     onClick: {
-      type: Function,
+      type: Function as PropType<() => void>,
       required: true,
     },
   },

--- a/src/components/uiComponents.ts
+++ b/src/components/uiComponents.ts
@@ -7,10 +7,10 @@ import type {
   OrganizationSwitcherProps,
   SignInProps,
   SignUpProps,
-  UserButtonProps,
   UserProfileProps,
 } from '@clerk/types'
 import { useClerk } from '../composables/useClerk'
+import { UserButton } from './UserButton'
 import { ClerkLoaded } from './controlComponents'
 
 type AnyObject = Record<string, any>
@@ -72,15 +72,6 @@ export const UserProfile = defineComponent((props: UserProfileProps) => {
   })
 })
 
-export const UserButton = defineComponent((props: UserButtonProps) => {
-  const clerk = useClerk()
-  return () => h(UIPortal, {
-    mount: clerk.mountUserButton,
-    unmount: clerk.unmountUserButton,
-    props,
-  })
-})
-
 export const OrganizationProfile = defineComponent((props: OrganizationProfileProps) => {
   const clerk = useClerk()
   return () => h(UIPortal, {
@@ -116,3 +107,7 @@ export const OrganizationList = defineComponent((props: OrganizationListProps) =
     props,
   })
 })
+
+export {
+  UserButton,
+}


### PR DESCRIPTION
This PR adds ability to add custom menu items to the `<UserButton />` component.

Example:

```vue
<template>
  <UserButton>
    <UserButton.Link label="Terms" href="/terms">
      <template #labelIcon>
        <TermsIcon />
      </template>
    </UserButton.Link>
    <UserButton.Action label="Chat Modal" @click="openChat">
      <template #labelIcon>
        <ChatIcon />
      </template>
    </UserButton.Action>
  </UserButton>
</template>

```