### PR TITLE
chore: Wrap custom menu items in another component

### DIFF
--- a/.changeset/red-geckos-hear.md
+++ b/.changeset/red-geckos-hear.md
@@ -1,0 +1,26 @@
+---
+"vue-clerk": patch
+---
+
+feat: Add custom menu items to UserButton component
+
+Example usage:
+
+```vue
+<template>
+  <UserButton>
+    <UserButton.MenuItems>
+      <UserButton.Link label="Terms" href="/custom-pages">
+        <template #labelIcon>
+          <TermsIcon />
+        </template>
+      </UserButton.Link>
+      <UserButton.Action label="Chat Modal" @click="openChatModal">
+        <template #labelIcon>
+          <ChatIcon />
+        </template>
+      </UserButton.Action>
+    </UserButton.MenuItems>
+  </UserButton>
+</template>
+```

--- a/playground/components/CustomUserButton.vue
+++ b/playground/components/CustomUserButton.vue
@@ -9,19 +9,21 @@ function openChatModal() {
 
 <template>
   <UserButton>
-    <UserButton.Link label="Terms" href="/custom-pages">
-      <template #labelIcon>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-        </svg>
-      </template>
-    </UserButton.Link>
-    <UserButton.Action label="Chat Modal" @click="openChatModal">
-      <template #labelIcon>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
-          <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
-        </svg>
-      </template>
-    </userbutton.action>
+    <UserButton.MenuItems>
+      <UserButton.Link label="Terms" href="/custom-pages">
+        <template #labelIcon>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+            <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+          </svg>
+        </template>
+      </UserButton.Link>
+      <UserButton.Action label="Chat Modal" @click="openChatModal">
+        <template #labelIcon>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor">
+            <path d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z" />
+          </svg>
+        </template>
+      </UserButton.Action>
+    </UserButton.MenuItems>
   </UserButton>
 </template>

--- a/src/components/UserButton.ts
+++ b/src/components/UserButton.ts
@@ -1,4 +1,4 @@
-import type { Component, PropType } from 'vue'
+import type { Component, PropType, VNode } from 'vue'
 import { Teleport, computed, defineComponent, h, ref, watchEffect } from 'vue'
 import type { CustomMenuItem, UserButtonProps } from '@clerk/types'
 import { useClerk } from '../composables/useClerk'
@@ -9,7 +9,10 @@ const UserButtonRoot = defineComponent((props: UserButtonProps, { slots }) => {
   const el = ref<HTMLDivElement | null>(null)
   const teleportDestinationMap = ref<Map<Component, HTMLDivElement>>(new Map())
 
-  const menuSlotItems = slots.default?.()
+  const menuSlotItemsRoot = slots.default?.()?.[0]
+
+  // @ts-expect-error: Add `default` slot type
+  const menuSlotItems = menuSlotItemsRoot?.children?.default?.() as VNode[]
 
   const customMenuItems = computed<CustomMenuItem[]>(() => {
     return menuSlotItems?.map((item) => {
@@ -59,6 +62,10 @@ const UserButtonRoot = defineComponent((props: UserButtonProps, { slots }) => {
   ])
 })
 
+const UserButtonMenuItems = defineComponent((_props, { slots }) => {
+  return () => slots.default?.()
+})
+
 const UserButtonLink = defineComponent({
   inheritAttrs: false,
   props: {
@@ -93,4 +100,4 @@ const UserButtonAction = defineComponent({
   },
 })
 
-export const UserButton = Object.assign(UserButtonRoot, { Link: UserButtonLink, Action: UserButtonAction })
+export const UserButton = Object.assign(UserButtonRoot, { MenuItems: UserButtonMenuItems, Link: UserButtonLink, Action: UserButtonAction })


### PR DESCRIPTION
Follow up to this PR - https://github.com/wobsoriano/vue-clerk/pull/91

This PR wraps the menu items in a `<UserButton.MenuItems>` component to match the React counterpart