### PR TITLE
chore: Export all `@clerk/backend` exports

### DIFF
--- a/.changeset/dirty-bugs-add.md
+++ b/.changeset/dirty-bugs-add.md
@@ -1,0 +1,5 @@
+---
+"vue-clerk": patch
+---
+
+Export all `@clerk/backend` exports in `vue-clerk/server`

--- a/.changeset/dirty-bugs-add.md
+++ b/.changeset/dirty-bugs-add.md
@@ -2,4 +2,4 @@
 "vue-clerk": patch
 ---
 
-Export all `@clerk/backend` exports in `vue-clerk/server`
+Export all `@clerk/backend` exports through `vue-clerk/server`

--- a/apps/docs/guides/nuxt.md
+++ b/apps/docs/guides/nuxt.md
@@ -91,7 +91,7 @@ definePageMeta({ middleware: 'guest', auth: { authenticatedRedirectUrl: '/profil
 
 ## 5. Protect your API endpoints
 
-To protect your routes, use the `getAuth()` function in your event handlers. This function retrieves the authentication state from the event object eturning an Auth object that includes the `userId`, allowing you to determine if the user is authenticated..
+To protect your routes, use the `getAuth()` function in your event handlers. This function retrieves the authentication state from the event object returning an [`Auth`](https://clerk.com/docs/references/nextjs/auth-object#auth-object) object that includes the `userId`, allowing you to determine if the user is authenticated..
 
 ```ts
 import { clerkClient, getAuth } from 'vue-clerk/server'

--- a/apps/docs/guides/nuxt.md
+++ b/apps/docs/guides/nuxt.md
@@ -91,14 +91,16 @@ definePageMeta({ middleware: 'guest', auth: { authenticatedRedirectUrl: '/profil
 
 ## 5. Protect your API endpoints
 
+To protect your routes, use the `getAuth()` function in your event handlers. This function retrieves the authentication state from the event object eturning an Auth object that includes the `userId`, allowing you to determine if the user is authenticated..
+
 ```ts
-import { clerkClient, getAuth } from '#clerk'
+import { clerkClient, getAuth } from 'vue-clerk/server'
 
 export default eventHandler((event) => {
   const { userId } = getAuth(event)
 
   if (!userId) {
-    setResponseStatus(event, 403)
+    setResponseStatus(event, 401)
     return
   }
 

--- a/apps/playground/server/api/protected.ts
+++ b/apps/playground/server/api/protected.ts
@@ -1,4 +1,4 @@
-import { clerkClient, getAuth } from '#clerk'
+import { clerkClient, getAuth } from 'vue-clerk/server'
 
 export default eventHandler((event) => {
   const auth = getAuth(event)

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -62,7 +62,13 @@ export default defineNuxtModule<ModuleOptions>({
       write: true,
       getContents: () => [
         'declare module \'#clerk\' {',
+        '  /**',
+        '   * @deprecated Import clerkClient from \'vue-clerk/server\' instead.',
+        '   */',
         `  const clerkClient: typeof import('${resolver.resolve('./runtime/server/clerkClient')}').clerkClient`,
+        '  /**',
+        '   * @deprecated Import getAuth from \'vue-clerk/server\' instead.',
+        '   */',
         `  const getAuth: typeof import('${resolver.resolve('./runtime/server/clerkClient')}').getAuth`,
         '}',
       ].join('\n'),

--- a/packages/nuxt/src/runtime/server/index.ts
+++ b/packages/nuxt/src/runtime/server/index.ts
@@ -1,0 +1,3 @@
+export * from '@clerk/backend'
+export { clerkClient } from './clerkClient'
+export { getAuth } from './clerkClient'

--- a/packages/vue-clerk/package.json
+++ b/packages/vue-clerk/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/nuxt/types.d.ts",
       "import": "./dist/nuxt/module.mjs",
       "require": "./dist/nuxt/module.cjs"
+    },
+    "./server": {
+      "types": "./dist/nuxt/runtime/server/index.d.ts",
+      "import": "./dist/nuxt/runtime/server/index.js"
     }
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
This PR re-exports all `@clerk/backend` exports and can be imported in `vue-clerk/server`.