### PR TITLE
Handle Promise in clerkMiddleware

### DIFF
--- a/.changeset/wise-wolves-sit.md
+++ b/.changeset/wise-wolves-sit.md
@@ -1,0 +1,5 @@
+---
+"vue-clerk": patch
+---
+
+Handle Promise in `clerkMiddleware`

--- a/packages/nuxt/src/runtime/server/clerkMiddleware.ts
+++ b/packages/nuxt/src/runtime/server/clerkMiddleware.ts
@@ -15,7 +15,7 @@ function toWebRequest(event: H3Event) {
   })
 }
 
-type Handler = (event: H3Event) => void
+type Handler = (event: H3Event) => void | Promise<void>
 
 /**
  * Integrates Clerk authentication into your Nuxt application through Middleware.
@@ -71,7 +71,7 @@ export function clerkMiddleware(handler?: Handler) {
     event.context.auth = authObject
     event.context.__clerk_initial_state = createInitialState(authObject)
 
-    handler?.(event)
+    await handler?.(event)
   })
 }
 


### PR DESCRIPTION
I thought I went crazy, without `await` attempting to use an async function in a custom middleware causes a whole bunch of problems, the Promise is resolved randomly during the server invocation.

```ts
export default clerkMiddleware(async (event) => {
  await db.select()
})
```